### PR TITLE
Fix whitespace issue on feature category names in Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 generate_count_matrix_ADTs
+.DS_Store

--- a/barcode_utils.hpp
+++ b/barcode_utils.hpp
@@ -161,7 +161,7 @@ inline void parse_one_line(const std::string& line, int& n_barcodes, int& barcod
 
 	pos = line.find_first_of(',');
 
-	if (pos != std::string::npos) { index_seq = line.substr(0, pos); index_name = line.substr(pos + 1); trim(index_name); }
+	if (pos != std::string::npos) { index_seq = line.substr(0, pos); trim(index_seq); index_name = line.substr(pos + 1); trim(index_name); }
 	else { index_seq = line; index_name = line; }
 
 	if (barcode_len == 0) barcode_len = index_seq.length();

--- a/barcode_utils.hpp
+++ b/barcode_utils.hpp
@@ -142,7 +142,7 @@ inline void ltrim(std::string &s) {
 }
 
 inline void rtrim(std::string& s) {
-	s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
+    s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
         return !std::isspace(ch);
     }).base(), s.end());
 }

--- a/barcode_utils.hpp
+++ b/barcode_utils.hpp
@@ -135,6 +135,24 @@ inline void mutate_index(HashType& index_dict, uint64_t binary_id, int len, int 
 	}
 }
 
+inline void ltrim(std::string &s) {
+    s.erase(s.begin(), std::find_if(s.begin(), s.end(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }));
+}
+
+inline void rtrim(std::string& s) {
+	s.erase(std::find_if(s.rbegin(), s.rend(), [](unsigned char ch) {
+        return !std::isspace(ch);
+    }).base(), s.end());
+}
+
+// trim from both ends (in place)
+inline void trim(std::string &s) {
+    rtrim(s);
+    ltrim(s);
+}
+
 inline void parse_one_line(const std::string& line, int& n_barcodes, int& barcode_len, HashType& index_dict, std::vector<std::string>& index_names, int max_mismatch, bool convert_cell_barcode) {
 	std::string index_name, index_seq;
 	std::size_t pos;
@@ -143,7 +161,7 @@ inline void parse_one_line(const std::string& line, int& n_barcodes, int& barcod
 
 	pos = line.find_first_of(',');
 
-	if (pos != std::string::npos) { index_seq = line.substr(0, pos); index_name = line.substr(pos + 1); }
+	if (pos != std::string::npos) { index_seq = line.substr(0, pos); index_name = line.substr(pos + 1); trim(index_name); }
 	else { index_seq = line; index_name = line; }
 
 	if (barcode_len == 0) barcode_len = index_seq.length();
@@ -160,7 +178,7 @@ inline void parse_one_line(const std::string& line, int& n_barcodes, int& barcod
 	else mutate_index(index_dict, barcode_to_binary(index_seq), index_seq.length(), n_barcodes, max_mismatch, 0, 0);
 
 	index_names.push_back(index_name);
-	++n_barcodes;	
+	++n_barcodes;
 }
 
 

--- a/generate_count_matrix_ADTs.cpp
+++ b/generate_count_matrix_ADTs.cpp
@@ -303,7 +303,7 @@ void process_reads(ReadParser *parser, int thread_id) {
 			if (valid_feature) {
 				binary_feature = barcode_to_binary(feature_barcode);
 				feature_iter = feature_index.find(binary_feature);
-				valid_feature = feature_iter != feature_index.end() && feature_iter->second.item_id >= 0;				
+				valid_feature = feature_iter != feature_index.end() && feature_iter->second.item_id >= 0;
 			}
 
 			n_valid_cell_ += valid_cell;
@@ -479,10 +479,10 @@ int main(int argc, char* argv[]) {
 	fout.close();
 
 	printf("%s.report.txt is written.\n", output_name.c_str());
-	
+
 	end_ = time(NULL);
 	printf("Outputs are written. Time spent = %.2fs.\n", difftime(end_, interim_));
-	
+
 	printf("Total time spent (not including destruct objects) = %.2fs.\n", difftime(end_, start_));
 
 	return 0;


### PR DESCRIPTION
## Issue

In Windows, if the sample sheet is specified in the following way:

```
XXXX,feature_name,hashing
```

Then the category name `hashing` is stored actually as `hashing\r`, and therefore the resulting hashing count matrix would have `xxxx.hashing\r.csv`.

## Reason

Windows has `\r\n` for line breaker, while UNIX systems use `\n`, and C++ `getline` function only removes `\n`.

## Solution

In `parse_one_line` function of `barcode.utils.hpp`, apply `trim` function to `index_name` variable to remove any leading or trailing whitespace.