### PR TITLE
Support feature barcode file with barcodes not grouped by modalities

### DIFF
--- a/generate_count_matrix_ADTs.cpp
+++ b/generate_count_matrix_ADTs.cpp
@@ -410,14 +410,9 @@ int main(int argc, char* argv[]) {
 
 	printf("Load feature barcodes.\n");
 	parse_sample_sheet(argv[2], n_feature, feature_blen, feature_index, feature_names, max_mismatch_feature);
-	// Sort feature_names if modality column presents
-	if (!feature_names.empty() && feature_names[0].find_first_of(',') != string::npos) {
-		sort(feature_names.begin(), feature_names.end(),
-			[](string s1, string s2) {
-				return s1.substr(s1.find_first_of(',') + 1) < s2.substr(s2.find_first_of(',') + 1);
-			}
-		);
-	}
+	// Sort feature_names and reindex feature_index if modality column presents
+	if (!feature_names.empty() && feature_names[0].find_first_of(',') != string::npos)
+		group_by_modality(feature_index, feature_names);
 	detected_ftype = parse_feature_names(n_feature, feature_names, n_cat, cat_names, cat_nfs, feature_categories);
 
 	parse_input_directory(argv[3]);

--- a/generate_count_matrix_ADTs.cpp
+++ b/generate_count_matrix_ADTs.cpp
@@ -410,6 +410,14 @@ int main(int argc, char* argv[]) {
 
 	printf("Load feature barcodes.\n");
 	parse_sample_sheet(argv[2], n_feature, feature_blen, feature_index, feature_names, max_mismatch_feature);
+	// Sort feature_names if modality column presents
+	if (!feature_names.empty() && feature_names[0].find_first_of(',') != string::npos) {
+		sort(feature_names.begin(), feature_names.end(),
+			[](string s1, string s2) {
+				return s1.substr(s1.find_first_of(',') + 1) < s2.substr(s2.find_first_of(',') + 1);
+			}
+		);
+	}
 	detected_ftype = parse_feature_names(n_feature, feature_names, n_cat, cat_names, cat_nfs, feature_categories);
 
 	parse_input_directory(argv[3]);


### PR DESCRIPTION
## Issue

If the provided feature barcode file doesn't specified barcodes grouped by modalities, the software will treat modalities of the same name as separate, and overwrite the resulting count matrices.

## Solution

After `parse_sample_sheet()` on feature barcode file, do the following:
1. Sort `feature_names` based on the modality column values;
2. Update `feature_names` accordingly;
3. Update the `item_id` field of `feature_index` hashmap accordingly.

Step 2 and 3 are skipped if the `feature_names` is already grouped.