### PR TITLE
Bug fix and user-friendly improvement

### DIFF
--- a/barcode_utils.hpp
+++ b/barcode_utils.hpp
@@ -198,7 +198,7 @@ inline void parse_one_line(const std::string& line, int& n_barcodes, int& barcod
 	if (pos != std::string::npos) { index_seq = line.substr(0, pos); trim(index_seq); index_name = line.substr(pos + 1); trim(index_name); }
 	else { index_seq = line; index_name = line; trim(index_seq); trim(index_name); }
 
-	if (index_seq.empty() || index_name.empty()) return;
+	if (index_seq.empty() && index_name.empty()) return;
 
 	if (barcode_len == 0) barcode_len = index_seq.length();
 	else assert(barcode_len == index_seq.length());

--- a/barcode_utils.hpp
+++ b/barcode_utils.hpp
@@ -196,7 +196,9 @@ inline void parse_one_line(const std::string& line, int& n_barcodes, int& barcod
 	pos = line.find_first_of(',');
 
 	if (pos != std::string::npos) { index_seq = line.substr(0, pos); trim(index_seq); index_name = line.substr(pos + 1); trim(index_name); }
-	else { index_seq = line; index_name = line; }
+	else { index_seq = line; index_name = line; trim(index_seq); trim(index_name); }
+
+	if (index_seq.empty() || index_name.empty()) return;
 
 	if (barcode_len == 0) barcode_len = index_seq.length();
 	else assert(barcode_len == index_seq.length());
@@ -215,6 +217,18 @@ inline void parse_one_line(const std::string& line, int& n_barcodes, int& barcod
 	++n_barcodes;
 }
 
+inline void skip_bom(std::string& line) {
+	size_t start = 0;
+
+	if (line.length() >= 3 && line.substr(0, 3) == "\xEF\xBB\xBF")   // UTF-8
+		start = 3;
+	else if (line.length() >= 2 && (line.substr(0, 2) == "\xFF\xFE" or line.substr(0, 2) == "\xFE\xFF"))    // UTF-16
+		start = 2;
+	else if (line.length() >= 4 && (line.substr(0, 4) == "\x00\x00\xFE\xFF" or line.substr(0, 4) == "\xFF\xFE\x00\x00"))    // UTF-32
+		start = 4;
+
+	line = line.substr(start);
+}
 
 void parse_sample_sheet(const std::string& sample_sheet_file, int& n_barcodes, int& barcode_len, HashType& index_dict, std::vector<std::string>& index_names, int max_mismatch = 1, bool convert_cell_barcode = false) {
 	std::string line;
@@ -224,13 +238,27 @@ void parse_sample_sheet(const std::string& sample_sheet_file, int& n_barcodes, i
 	index_dict.clear();
 	index_names.clear();
 
+	bool is_first_line = true;
+
 	if (sample_sheet_file.length() > 3 && sample_sheet_file.substr(sample_sheet_file.length() - 3, 3) == ".gz") { // input sample sheet is gzipped
 		iGZipFile gin(sample_sheet_file);
-		while (gin.next(line)) parse_one_line(line, n_barcodes, barcode_len, index_dict, index_names, max_mismatch, convert_cell_barcode);
+		while (gin.next(line)) {
+			if (is_first_line) {
+				skip_bom(line);
+				is_first_line = false;
+			}
+			parse_one_line(line, n_barcodes, barcode_len, index_dict, index_names, max_mismatch, convert_cell_barcode);
+		}
 	}
 	else {
 		std::ifstream fin(sample_sheet_file);
-		while (std::getline(fin, line)) parse_one_line(line, n_barcodes, barcode_len, index_dict, index_names, max_mismatch, convert_cell_barcode);
+		while (std::getline(fin, line)) {
+			if (is_first_line) {
+				skip_bom(line);
+				is_first_line = false;
+			}
+			parse_one_line(line, n_barcodes, barcode_len, index_dict, index_names, max_mismatch, convert_cell_barcode);
+		}
 		fin.close();
 	}
 	printf("%s is parsed. n_barcodes = %d, and barcode_len = %d.\n", sample_sheet_file.c_str(), n_barcodes, barcode_len);

--- a/generate_count_matrix_ADTs.cpp
+++ b/generate_count_matrix_ADTs.cpp
@@ -114,6 +114,11 @@ void parse_input_directory(char* input_dirs) {
 
 		input_dir = strtok(NULL, ",");
 	}
+
+	if (inputs.empty()) {
+		printf("No FASTQ file found in input folder(s): \"%s\"!\n", input_dirs);
+		exit(-1);
+	}
 }
 
 


### PR DESCRIPTION
Process barcode sheets:
* **Issue 1:** When parsing UTF encoding sheets, the first cell/feature always has longer sequence length. E.g. in UTF-8, first feature has length `n+3`, while `n` is the actual sequence length.
  * **Solution:** Remove leading BOM characters.
* **Issue 2:** When processing lines such as `,`, cause errors as it considers them as cells/features with sequence of length `0`.
  * **Solution:** Skip lines with both empty sequence and name.

Parse input directories:
* **Issue:** Even if no fastq file found in input dirs, still continue to following steps until segmentation fault.
  * **Solution:** If no fastq file is found (i.e. `inputs.empty()` at the end of `parse_input_directory()`), exit with clear error message.