### PR TITLE
Auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![](https://img.shields.io/github/v/release/lilab-bcb/cumulus_feature_barcoding.svg)](https://github.com/lilab-bcb/cumulus_feature_barcoding/releases)
 
-A fast C++ tool to extract feature-count matrix from sequence reads in FASTQ files. We uses isal-l for decompressing and Heng Li's kseq library for read parsing. It is used by Cumulus for feature-count matrix generation of cell hashing, nucleus hashing, CITE-Seq and Perturb-seq protocols, using either 10x Genomics V2 or V3 chemistry.
+A fast C++ tool to extract feature-count matrix from sequence reads in FASTQ files. We uses isal-l for decompressing and Heng Li's kseq library for read parsing. It is used by Cumulus for feature-count matrix generation of cell hashing, nucleus hashing, CITE-Seq and Perturb-seq protocols, using either 10x Genomics V2, V3 or V4 chemistry.
 
 ## Installation
 
@@ -36,6 +36,20 @@ make all
 ```
 
 to see its usage.
+
+5. The 10x barcode inclusion list files are needed. Below is a list of them which you can find in Cell Ranger v9.0.1 source code:
+
+* `cellranger-9.0.1/lib/python/cellranger/barcodes/`:
+  * `3M-3pgex-may-2023_TRU.txt.gz`
+  * `3M-5pgex-jan-2023.txt.gz`
+  * `3M-february-2018_TRU.txt.gz`
+  * `737K-arc-v1.txt.gz`
+  * `737K-august-2016.txt`
+* `cellranger-9.0.1/lib/python/cellranger/barcodes/translation/`:
+  * `3M-3pgex-may-2023_NXT.txt.gz`
+  * `3M-february-2018_NXT.txt.gz`
+
+Just put these 7 files in the same folder, and specify it as `cell_barcodes_dir` argument for `generate_count_matrix_ADTs` command.
 
 ### Compile on Mac OS
 

--- a/barcode_utils.hpp
+++ b/barcode_utils.hpp
@@ -224,7 +224,7 @@ inline void skip_bom(std::string& line) {
 	line = line.substr(start);
 }
 
-void parse_sample_sheet(const std::string& sample_sheet_file, int& n_barcodes, int& barcode_len, HashType& index_dict, std::vector<std::string>& index_names, int max_mismatch = 1, bool verbose = true, bool is_process = true) {
+void parse_sample_sheet(const std::string& sample_sheet_file, int& n_barcodes, int& barcode_len, HashType& index_dict, std::vector<std::string>& index_names, int max_mismatch = 1, bool verbose = true) {
 	std::string line;
 
 	n_barcodes = 0;
@@ -241,7 +241,7 @@ void parse_sample_sheet(const std::string& sample_sheet_file, int& n_barcodes, i
 				skip_bom(line);
 				is_first_line = false;
 			}
-			parse_one_line(line, n_barcodes, barcode_len, index_dict, index_names, max_mismatch, is_process);
+			parse_one_line(line, n_barcodes, barcode_len, index_dict, index_names, max_mismatch);
 		}
 	}
 	else {
@@ -251,7 +251,7 @@ void parse_sample_sheet(const std::string& sample_sheet_file, int& n_barcodes, i
 				skip_bom(line);
 				is_first_line = false;
 			}
-			parse_one_line(line, n_barcodes, barcode_len, index_dict, index_names, max_mismatch, is_process);
+			parse_one_line(line, n_barcodes, barcode_len, index_dict, index_names, max_mismatch);
 		}
 		fin.close();
 	}

--- a/barcode_utils.hpp
+++ b/barcode_utils.hpp
@@ -187,7 +187,7 @@ inline void group_by_modality(HashType& index_dict, std::vector<std::string>& in
 	}
 }
 
-inline void parse_one_line(const std::string& line, int& n_barcodes, int& barcode_len, HashType& index_dict, std::vector<std::string>& index_names, int max_mismatch, bool is_process) {
+inline void parse_one_line(const std::string& line, int& n_barcodes, int& barcode_len, HashType& index_dict, std::vector<std::string>& index_names, int max_mismatch) {
 	std::string index_name, index_seq;
 	std::size_t pos;
 
@@ -207,7 +207,7 @@ inline void parse_one_line(const std::string& line, int& n_barcodes, int& barcod
 	if (max_mismatch == 1) mutate_index_one_mismatch(index_dict, index_seq, n_barcodes);
 	else mutate_index(index_dict, barcode_to_binary(index_seq), index_seq.length(), n_barcodes, max_mismatch, 0, 0);
 
-	if (is_process) index_names.push_back(index_name);    // Only use index_names when processing cell barcodes for feature barcoding; ignore if auto-detecting chemistry
+	index_names.push_back(index_name);
 	++n_barcodes;
 }
 

--- a/generate_count_matrix_ADTs.cpp
+++ b/generate_count_matrix_ADTs.cpp
@@ -265,7 +265,7 @@ void detect_chemistry() {
 		for (int i = 0; i < n_chems; ++i) {
 			cur_chem = it->second[i];
 			chem_names[i] = cur_chem;
-			parse_sample_sheet(cb_inclusion_file_dict[cur_chem], n_cb, len_cb, chem_cb_indexes[i], dummy, 0, false, false);
+			parse_sample_sheet(cb_inclusion_file_dict[cur_chem], n_cb, len_cb, chem_cb_indexes[i], dummy, 0, false);
 		}
 
 		// Count cell barcode matches

--- a/generate_count_matrix_ADTs.cpp
+++ b/generate_count_matrix_ADTs.cpp
@@ -265,7 +265,6 @@ void detect_chemistry() {
 		for (int i = 0; i < n_chems; ++i) {
 			cur_chem = it->second[i];
 			chem_names[i] = cur_chem;
-			// YIMING: Should I consider the case when len_cb varies in chemistries?
 			parse_sample_sheet(cb_inclusion_file_dict[cur_chem], n_cb, len_cb, chem_cb_indexes[i], dummy, 0, false, false);
 		}
 
@@ -301,7 +300,10 @@ void detect_chemistry() {
 		if (max_cnt > 0) {
 			if (snd_max_cnt > 0) {
 				printf("[Chemistry detection] Top 2 chemistries in first %d reads: %s (%d matches), %s (%d matches).\n", nskim, chem_max.c_str(), max_cnt, chem_snd_max.c_str(), snd_max_cnt);
-				if (static_cast<float>(max_cnt - snd_max_cnt) / nskim < 0.1) {
+				if (static_cast<float>(max_cnt) / nskim < 0.05) {
+					printf("No chemistry has matched reads exceeding 5%% of first %d reads! Please check if you specify the correct chemistry type, or if it is a 10x assay!\n", nskim);
+					exit(-1);
+				} else if (static_cast<float>(max_cnt - snd_max_cnt) / nskim < 0.1) {
 					printf("Top 2 chemistries have matched reads < 10%% of first %d reads! Cannot decide assay type! Please check if it is a 10x assay!\n", nskim);
 					exit(-1);
 				}

--- a/generate_count_matrix_ADTs.cpp
+++ b/generate_count_matrix_ADTs.cpp
@@ -506,7 +506,7 @@ int main(int argc, char* argv[]) {
 
 	n_threads = 2;
 	chemistry = "auto";
-	max_mismatch_cell = 0;
+	max_mismatch_cell = -1;
 	feature_type = "antibody";
 	max_mismatch_feature = 2;
 	umi_len = 12;

--- a/generate_count_matrix_ADTs.cpp
+++ b/generate_count_matrix_ADTs.cpp
@@ -27,6 +27,32 @@ using namespace std;
 const int totalseq_A_pos = 0;
 const int totalseq_BC_pos = 10;
 
+unordered_map<string, vector<string>> compound_chemistry_dict = {
+	{"auto", {"10x_v2", "SC3Pv3:Poly-A", "SC3Pv3:CS1", "SC3Pv4:Poly-A", "SC3Pv4:CS1", "SC5Pv3", "multiome"}},
+	{"threeprime", {"10x_v2", "SC3Pv3:Poly-A", "SC3Pv3:CS1", "SC3Pv4:Poly-A", "SC3Pv4:CS1"}},
+	{"fiveprime", {"10x_v2", "SC5Pv3"}},
+	{"SC3Pv3", {"SCP3v3:Poly-A", "SCP3v3:CS1"}},
+	{"SC3Pv4", {"SC3Pv4:Poly-A", "SC3Pv4:CS1"}},
+};
+
+unordered_map<string, string> cb_inclusion_file_dict = {
+	{"10x_v2", "737K-august-2016.txt"},
+	{"SC3Pv2", "737K-august-2016.txt.gz"},
+	{"SC5Pv2", "737K-august-2016.txt.gz"},
+	{"SC3Pv3:Poly-A", "3M-february-2018_TRU.txt.gz"},
+	{"SC3Pv3:CS1", "3M-february-2018_NXT.txt.gz"},
+	{"SC3Pv4:Poly-A", "3M-3pgex-may-2023_TRU.txt.gz"},
+	{"SC3Pv4:CS1", "3M-3pgex-may-2023_NXT.txt.gz"},
+	{"SC5Pv3", "3M-5pgex-jan-2023.txt.gz"},
+	{"multiome", "737K-arc-v1.txt.gz"},
+};
+
+// For auto-detect chemistry
+string cb_dir;
+vector<string> chem_names;
+vector<int> chem_cnts;
+vector<HashType> chem_cb_indexes;
+string chemistry;
 
 atomic<int> cnt, n_valid, n_valid_cell, n_valid_feature, prev_cnt; // cnt: total number of reads; n_valid, reads with valid cell barcode and feature barcode; n_valid_cell, reads with valid cell barcode; n_valid_feature, reads with valid feature barcode; prev_cnt: for printing # of reads processed purpose
 
@@ -209,6 +235,107 @@ inline bool extract_feature_barcode(const string& sequence, int feature_length, 
 }
 
 
+void detect_chemistry() {
+	// Redirect 10x barcode inclusion list files
+	for (auto& p : cb_inclusion_file_dict) {
+		p.second = cb_dir + p.second;
+	}
+
+	auto it = compound_chemistry_dict.find(chemistry);
+	if (it == compound_chemistry_dict.end()) {    // The given chemistry name is not a compound chemistry type
+		if (cb_inclusion_file_dict.find(chemistry) == cb_inclusion_file_dict.end()) {
+			printf("Unknown chemistry type: %s!\n", chemistry.c_str());
+			exit(-1);
+		}
+	} else {
+		// A compound chemistry is given. Auto-detect
+		const int nskim = 10000; // Look at first 10,000 reads
+		int n_chems = it->second.size();
+		string cur_chem;
+		int n_cb, len_cb;
+		vector<string> dummy;  // Placeholder. Not used.
+		uint64_t binary_cb;
+		Read read1;
+		size_t pos;
+
+		//Build count map
+		chem_names = vector<string>(n_chems, "");
+		chem_cnts = vector<int>(n_chems, 0);
+		chem_cb_indexes = vector<HashType>(n_chems, HashType());
+		for (int i = 0; i < n_chems; ++i) {
+			cur_chem = it->second[i];
+			chem_names[i] = cur_chem;
+			// YIMING: Should I consider the case when len_cb varies in chemistries?
+			parse_sample_sheet(cb_inclusion_file_dict[cur_chem], n_cb, len_cb, chem_cb_indexes[i], dummy, 0, false, false);
+		}
+
+		// Count cell barcode matches
+		for (auto&& input_pair : inputs) {
+			iGZipFile gzip_in_r1(input_pair[0]);
+			while (gzip_in_r1.next(read1) && cnt < nskim) {
+				binary_cb = barcode_to_binary(safe_substr(read1.seq, 0, len_cb));
+				for (int i = 0; i < n_chems; ++i) {
+					if (chem_cb_indexes[i].find(binary_cb) != chem_cb_indexes[i].end())
+						++chem_cnts[i];
+				}
+				++cnt;
+			}
+			if (cnt == nskim) break;
+		}
+
+		// Decide chemistry based on count results
+		int max_cnt = -1;
+		int snd_max_cnt = -1;
+		string chem_max;
+		string chem_snd_max;
+		string capture_method;
+
+		for (int i = 0; i < n_chems; ++i)
+			if (chem_cnts[i] > max_cnt) {
+				snd_max_cnt = max_cnt;
+				chem_snd_max = chem_max;
+				max_cnt = chem_cnts[i];
+				chem_max = chem_names[i];
+			}
+
+		if (max_cnt > 0) {
+			if (snd_max_cnt > 0) {
+				printf("[Chemistry detection] Top 2 chemistries in first %d reads: %s (%d matches), %s (%d matches).\n", nskim, chem_max.c_str(), max_cnt, chem_snd_max.c_str(), snd_max_cnt);
+				if (static_cast<float>(max_cnt - snd_max_cnt) / nskim < 0.1) {
+					printf("Top 2 chemistries have matched reads < 10%% of first %d reads! Cannot decide assay type! Please check if it is a 10x assay!\n", nskim);
+					exit(-1);
+				}
+			} else
+				printf("[Chemistry detection] Only 1 chemistry has matches in the first %d reads: %s (%d matches).\n", nskim, chem_max.c_str(), max_cnt);
+
+			chemistry = chem_max;
+			pos = chemistry.find_first_of(':');
+			if (pos != string::npos) {
+				// Decide totalseq_type and barcode_pos
+				capture_method = chemistry.substr(pos + 1);
+				if (feature_type == "antibody") {
+					totalseq_type = capture_method == "Poly-A" ? "TotalSeq-A" : "TotalSeq-B";
+					barcode_pos = totalseq_type == "TotalSeq-A" ? totalseq_A_pos : totalseq_BC_pos;
+				}
+			} else {
+				if (chemistry == "SC5Pv3" && feature_type == "antibody") {
+					totalseq_type = "TotalSeq-C";
+					barcode_pos = totalseq_BC_pos;
+				}
+			}
+
+			printf("[Chemistry detection] Detect %s chemistry.\n", chemistry.c_str());
+			if (totalseq_type != "")
+				printf("[Chemistry detection] Detect %s type, barcodes start from 0-based position %d.\n", totalseq_type.c_str(), barcode_pos);
+
+		} else {
+			printf("Failed at chemistry detection: No cell barcode match in the first %d reads! Please check if it is a 10x assay!", nskim);
+			exit(-1);
+		}
+	}
+}
+
+
 void detect_totalseq_type() {
 	const int nskim = 10000; // Look at first 10000 reads.
 	int ntotA, ntotBC, cnt;
@@ -353,14 +480,15 @@ void process_reads(ReadParser *parser, int thread_id) {
 
 int main(int argc, char* argv[]) {
 	if (argc < 5) {
-		printf("Usage: generate_count_matrix_ADTs cell_barcodes.txt[.gz] feature_barcodes.csv fastq_folders output_name [-p #] [--max-mismatch-cell #] [--feature feature_type] [--max-mismatch-feature #] [--umi-length len] [--barcode-pos #] [--convert-cell-barcode] [--scaffold-sequence sequence]\n");
-		printf("Arguments:\n\tcell_barcodes.txt[.gz]\t10x genomics barcode white list, either gzipped or not.\n");
+		printf("Usage: generate_count_matrix_ADTs cell_barcodes_dir feature_barcodes.csv fastq_folders output_name [-p #] [--max-mismatch-cell #] [--feature feature_type] [--max-mismatch-feature #] [--umi-length len] [--barcode-pos #] [--convert-cell-barcode] [--scaffold-sequence sequence]\n");
+		printf("Arguments:\n\tcell_barcodes_dir\tPath to the folder containing 10x genomics barcode inclusion list files, either gzipped or not.\n");
 		printf("\tfeature_barcodes.csv\tfeature barcode file;barcode,feature_name[,feature_category]. Optional feature_category is required only if hashing and citeseq data share the same sample index.\n");
 		printf("\tfastq_folders\tfolder containing all R1 and R2 FASTQ files ending with 001.fastq.gz .\n");
 		printf("\toutput_name\toutput file name prefix.\n");
 		printf("Options:\n");
 		printf("\t-p #\tnumber of threads. This number should be >= 2. [default: 2]\n");
-		printf("\t--max-mismatch-cell #\tmaximum number of mismatches allowed for cell barcodes. [default: 0]\n");
+		printf("\t--chemistry chemistry_type\tchemistry type. [default: auto]\n");
+		printf("\t--max-mismatch-cell #\tmaximum number of mismatches allowed for cell barcodes. [default: auto-decided by chemistry]\n");
 		printf("\t--feature feature_type\tfeature type can be either antibody or crispr. [default: antibody]\n");
 		printf("\t--max-mismatch-feature #\tmaximum number of mismatches allowed for feature barcodes. [default: 2]\n");
 		printf("\t--umi-length len\tlength of the UMI sequence. [default: 12]\n");
@@ -377,6 +505,7 @@ int main(int argc, char* argv[]) {
 	start_ = time(NULL);
 
 	n_threads = 2;
+	chemistry = "auto";
 	max_mismatch_cell = 0;
 	feature_type = "antibody";
 	max_mismatch_feature = 2;
@@ -389,6 +518,9 @@ int main(int argc, char* argv[]) {
 	for (int i = 5; i < argc; ++i) {
 		if (!strcmp(argv[i], "-p")) {
 			n_threads = atoi(argv[i + 1]);
+		}
+		if (!strcmp(argv[i], "--chemistry")) {
+			chemistry = argv[i + 1];
 		}
 		if (!strcmp(argv[i], "--max-mismatch-cell")) {
 			max_mismatch_cell = atoi(argv[i + 1]);
@@ -422,8 +554,19 @@ int main(int argc, char* argv[]) {
 
 	parse_input_directory(argv[3]);
 
+	cb_dir = argv[1];
+	if (cb_dir.length() > 0 && cb_dir[cb_dir.length()-1] != '/')
+		cb_dir += "/";
+
+	detect_chemistry();
+
+	// Determine UMI length, as well as max_mismatch_cell if not specified
+	umi_len = (chemistry == "10x_v2" || chemistry == "SC3Pv2" || chemistry == "SC5Pv2") ? 10 : 12;
+	if (max_mismatch_cell == -1)
+		max_mismatch_cell = (chemistry == "10x_v2" || chemistry == "SC3Pv2" || chemistry == "SC5Pv2" || chemistry == "multiome") ? 1 : 0;
+
 	if (feature_type == "antibody") {
-		if (barcode_pos < 0) detect_totalseq_type(); // if specify --barcode-pos, must be a customized assay
+		if (totalseq_type == "" && barcode_pos < 0) detect_totalseq_type(); // if specify --barcode-pos, must be a customized assay
 	}
     else {
 		if (feature_type != "crispr") {
@@ -435,8 +578,7 @@ int main(int argc, char* argv[]) {
 
 	interim_ = time(NULL);
 	printf("Load cell barcodes.\n");
-	convert_cell_barcode = convert_cell_barcode || (feature_type == "antibody" && totalseq_type == "TotalSeq-B");
-	parse_sample_sheet(argv[1], n_cell, cell_blen, cell_index, cell_names, max_mismatch_cell, convert_cell_barcode);
+	parse_sample_sheet(cb_inclusion_file_dict[chemistry], n_cell, cell_blen, cell_index, cell_names, max_mismatch_cell);
 	end_ = time(NULL);
 	printf("Time spent on parsing cell barcodes = %.2fs.\n", difftime(end_, interim_));
 


### PR DESCRIPTION
Detect the following settings by testing the first 10,000 reads:
* `chemistry`
* `totalseq_type` for antibody assays
* `barcode_pos`
* `umi_len`

Work with the new cell barcode inclusion lists for `SC3Pv3` and `SC3Pv4` since Cell Ranger v9.0.