### PR TITLE
Fix memory issue plus some improvement

### DIFF
--- a/datamatrix_utils.hpp
+++ b/datamatrix_utils.hpp
@@ -222,14 +222,15 @@ public:
 
 		if (total_cells > 1) std::sort(cell_ids.begin(), cell_ids.end());
 
-		std::vector<int> dummy(total_cells, 0), tot_umis(total_cells, 0);
-		std::vector<std::vector<int> > ADTs(total_features, dummy);
-
 		// Collect molecule info and stats
-		std::vector<int> barcode_idx;
-		std::vector<int> feature_idx;
+		int total_umis_count = get_total_umis();
+		std::vector<int> barcode_idx, feature_idx, umi_counts;
 		std::vector<std::string> umi_names;
-		std::vector<int> umi_counts;
+		std::vector<int> tot_umis(total_cells, 0);
+		barcode_idx.reserve(total_umis_count);
+		feature_idx.reserve(total_umis_count);
+		umi_names.reserve(total_umis_count);
+		umi_counts.reserve(total_umis_count);
 		for (int i = 0; i < total_cells; ++i) {
 			auto& one_cell = data_container[cell_ids[i]];
 			for (auto&& kv1 : one_cell) {
@@ -240,29 +241,33 @@ public:
 					umi_counts.push_back(kv2.second);
 					total_reads += kv2.second;
 					++total_umis;
-					++ADTs[kv1.first - feature_start][i];
 					++tot_umis[i];
 				}
 			}
 		}
 
-		// Create a CSR sparse matrix.
-		std::vector<int> csr_data;
-		std::vector<int> csr_indices;
-		std::vector<int> csr_indptr;
+		// Create a CSR sparse matrix directly from data_container.
+		std::vector<int> csr_data, csr_indices, csr_indptr;
 		std::vector<std::string> barcodes;
+		barcodes.reserve(total_cells);
+		csr_indptr.reserve(total_cells + 1);
 
 		int indptr = 0;
 		csr_indptr.push_back(indptr);
+		std::vector<int32_t> sorted_features;
 		for (int i = 0; i < total_cells; ++i) {
 			if (tot_umis[i] == 0) continue;
+			auto& one_cell = data_container[cell_ids[i]];
 			barcodes.push_back(cell_names[cell_ids[i]]);
-			for (int j = feature_start; j < feature_end; ++j)
-				if (ADTs[j - feature_start][i] > 0) {
-					csr_data.push_back(ADTs[j - feature_start][i]);
-					csr_indices.push_back(j - feature_start);
-					++indptr;
-				}
+			sorted_features.clear();
+			sorted_features.reserve(one_cell.size());
+			for (auto& kv : one_cell) sorted_features.push_back(kv.first);
+			std::sort(sorted_features.begin(), sorted_features.end());
+			for (int32_t feat : sorted_features) {
+				csr_data.push_back(one_cell[feat].size());
+				csr_indices.push_back(feat - feature_start);
+				++indptr;
+			}
 			csr_indptr.push_back(indptr);
 		}
 

--- a/datamatrix_utils.hpp
+++ b/datamatrix_utils.hpp
@@ -8,6 +8,7 @@
 #include <iomanip>
 #include <fstream>
 #include <sstream>
+#include <locale>
 #include <unordered_map>
 #include <H5Cpp.h>
 
@@ -282,6 +283,12 @@ public:
 
 		write_molecule_info_h5(output_name + "." + step, barcode_idx, barcodes, feature_idx, features, max_feature_name_len, umi_names, umi_counts, umi_len);
 		write_count_matrix_h5(output_name + "." + step, csr_data, csr_indices, csr_indptr, total_cells, total_features, barcodes, features, max_feature_name_len, feature_type, genome);
+
+		try {
+			report_buffer.imbue(std::locale("en_US.UTF-8"));
+		} catch (std::runtime_error&) {
+			report_buffer.imbue(std::locale(""));
+		}
 
 		if (step == "raw") {
 			report_buffer << std::endl<< "Section "<< output_name << std::endl;

--- a/datamatrix_utils.hpp
+++ b/datamatrix_utils.hpp
@@ -284,9 +284,10 @@ public:
 		write_molecule_info_h5(output_name + "." + step, barcode_idx, barcodes, feature_idx, features, max_feature_name_len, umi_names, umi_counts, umi_len);
 		write_count_matrix_h5(output_name + "." + step, csr_data, csr_indices, csr_indptr, total_cells, total_features, barcodes, features, max_feature_name_len, feature_type, genome);
 
+		// Print numbers in thousands separator format.
 		try {
 			report_buffer.imbue(std::locale("en_US.UTF-8"));
-		} catch (std::runtime_error&) {
+		} catch (std::runtime_error&) {  // In case macOS doesn't recognize "en_US.UTF-8" locale.
 			report_buffer.imbue(std::locale(""));
 		}
 

--- a/datamatrix_utils.hpp
+++ b/datamatrix_utils.hpp
@@ -8,7 +8,6 @@
 #include <iomanip>
 #include <fstream>
 #include <sstream>
-#include <locale>
 #include <unordered_map>
 #include <H5Cpp.h>
 
@@ -283,13 +282,6 @@ public:
 
 		write_molecule_info_h5(output_name + "." + step, barcode_idx, barcodes, feature_idx, features, max_feature_name_len, umi_names, umi_counts, umi_len);
 		write_count_matrix_h5(output_name + "." + step, csr_data, csr_indices, csr_indptr, total_cells, total_features, barcodes, features, max_feature_name_len, feature_type, genome);
-
-		// Print numbers in thousands separator format.
-		try {
-			report_buffer.imbue(std::locale("en_US.UTF-8"));
-		} catch (std::runtime_error&) {  // In case macOS doesn't recognize "en_US.UTF-8" locale.
-			report_buffer.imbue(std::locale(""));
-		}
 
 		if (step == "raw") {
 			report_buffer << std::endl<< "Section "<< output_name << std::endl;

--- a/generate_feature_barcode_matrices.cpp
+++ b/generate_feature_barcode_matrices.cpp
@@ -24,6 +24,12 @@
 
 using namespace std;
 
+static string format_commas(long long n) {
+	string s = to_string(n);
+	int pos = (int)s.length() - 3;
+	while (pos > 0) { s.insert(pos, ","); pos -= 3; }
+	return s;
+}
 
 string cb_dir;
 string chemistry;
@@ -270,7 +276,7 @@ void process_reads(ReadParser *parser, int thread_id) {
 		n_reads_valid_umi += n_reads_valid_umi_;
 
 		if (cnt - prev_cnt >= 1000000) {
-			printf("Processed %d reads.\n", cnt.load());
+			printf("Processed %s reads.\n", format_commas(cnt.load()).c_str());
 			prev_cnt = cnt.load();
 		}
 	}

--- a/generate_feature_barcode_matrices.cpp
+++ b/generate_feature_barcode_matrices.cpp
@@ -8,7 +8,6 @@
 #include <vector>
 #include <fstream>
 #include <iomanip>
-#include <locale>
 #include <algorithm>
 #include <memory>
 #include <atomic>
@@ -414,12 +413,6 @@ int main(int argc, char* argv[]) {
 
 	fout.open(output_name + ".report.txt");
 
-	// Print numbers in thousands separator format.
-	try {
-		fout.imbue(std::locale("en_US.UTF-8"));
-	} catch (std::runtime_error&) { // In case macOS doesn't recognize "en_US.UTF-8" locale.
-		fout.imbue(std::locale(""));
-	}
 	fout<< "Total number of reads: "<< cnt<< endl;
 	fout<< "Number of reads with valid cell barcodes: "<< n_valid_cell<< " ("<< fixed<< setprecision(2)<< n_valid_cell * 100.0 / cnt << "%)"<< endl;
 	fout<< "Number of reads with valid feature barcodes: "<< n_valid_feature<< " ("<< fixed<< setprecision(2)<< n_valid_feature * 100.0 / cnt << "%)"<< endl;

--- a/generate_feature_barcode_matrices.cpp
+++ b/generate_feature_barcode_matrices.cpp
@@ -412,7 +412,6 @@ int main(int argc, char* argv[]) {
 	ofstream fout;
 
 	fout.open(output_name + ".report.txt");
-
 	fout<< "Total number of reads: "<< cnt<< endl;
 	fout<< "Number of reads with valid cell barcodes: "<< n_valid_cell<< " ("<< fixed<< setprecision(2)<< n_valid_cell * 100.0 / cnt << "%)"<< endl;
 	fout<< "Number of reads with valid feature barcodes: "<< n_valid_feature<< " ("<< fixed<< setprecision(2)<< n_valid_feature * 100.0 / cnt << "%)"<< endl;

--- a/generate_feature_barcode_matrices.cpp
+++ b/generate_feature_barcode_matrices.cpp
@@ -8,6 +8,7 @@
 #include <vector>
 #include <fstream>
 #include <iomanip>
+#include <locale>
 #include <algorithm>
 #include <memory>
 #include <atomic>
@@ -24,6 +25,8 @@
 
 using namespace std;
 
+// Helper function to print numbers in thousands separator format.
+// This is only used in C-style printf function.
 static string format_commas(long long n) {
 	string s = to_string(n);
 	int pos = (int)s.length() - 3;
@@ -410,6 +413,13 @@ int main(int argc, char* argv[]) {
 	ofstream fout;
 
 	fout.open(output_name + ".report.txt");
+
+	// Print numbers in thousands separator format.
+	try {
+		fout.imbue(std::locale("en_US.UTF-8"));
+	} catch (std::runtime_error&) { // In case macOS doesn't recognize "en_US.UTF-8" locale.
+		fout.imbue(std::locale(""));
+	}
 	fout<< "Total number of reads: "<< cnt<< endl;
 	fout<< "Number of reads with valid cell barcodes: "<< n_valid_cell<< " ("<< fixed<< setprecision(2)<< n_valid_cell * 100.0 / cnt << "%)"<< endl;
 	fout<< "Number of reads with valid feature barcodes: "<< n_valid_feature<< " ("<< fixed<< setprecision(2)<< n_valid_feature * 100.0 / cnt << "%)"<< endl;


### PR DESCRIPTION
* Fix memory issue: Avoid creating a dense matrix `ADTs` when organizing output data in memory.
* For all vectors of fixed size but updated by `push_back()` function, initialize using `reserve()` function to allocation memory space in advance.
* Print counts in execution or final reports in thousands separator format: Implement a helper function `format_commas()` for the C-style `printf()` function.