### PR TITLE
Use long type for read counters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build and smoke test
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            build-essential \
+            libdeflate-dev \
+            libhdf5-dev \
+            libisal-dev
+
+      - name: Build
+        run: |
+          make clean
+          make all
+
+      - name: Smoke test CLI usage
+        run: |
+          test -x ./generate_feature_barcode_matrices
+
+          set +e
+          output=$(./generate_feature_barcode_matrices 2>&1)
+          exit_code=$?
+          set -e
+
+          test "$exit_code" -ne 0
+          grep -q "Usage: generate_feature_barcode_matrices" <<< "$output"

--- a/datamatrix_utils.hpp
+++ b/datamatrix_utils.hpp
@@ -207,7 +207,8 @@ public:
 		std::vector<int> cell_ids;
 		std::ofstream fout;
 
-		int total_cells = 0, total_reads = 0, total_umis = 0;
+		int total_cells = 0, total_umis = 0;
+		long total_reads = 0;
 		int total_features = feature_end - feature_start;
 
 		cell_ids.clear();
@@ -238,7 +239,7 @@ public:
 					feature_idx.push_back(kv1.first - feature_start);
 					umi_names.push_back(binary_to_barcode(kv2.first, umi_len));
 					umi_counts.push_back(kv2.second);
-					total_reads += kv2.second;
+					total_reads += static_cast<long>(kv2.second);
 					++total_umis;
 					++ADTs[kv1.first - feature_start][i];
 					++tot_umis[i];

--- a/generate_feature_barcode_matrices.cpp
+++ b/generate_feature_barcode_matrices.cpp
@@ -28,7 +28,7 @@ using namespace std;
 string cb_dir;
 string chemistry;
 
-atomic<int> cnt, n_valid, n_valid_cell, n_valid_feature, n_reads_valid_umi, prev_cnt; // cnt: total number of reads; n_valid, reads with valid cell barcode and feature barcode; n_valid_cell, reads with valid cell barcode; n_valid_feature, reads with valid feature barcode; prev_cnt: for printing # of reads processed purpose
+atomic<long> cnt, n_valid, n_valid_cell, n_valid_feature, n_reads_valid_umi, prev_cnt; // cnt: total number of reads; n_valid, reads with valid cell barcode and feature barcode; n_valid_cell, reads with valid cell barcode; n_valid_feature, reads with valid feature barcode; prev_cnt: for printing # of reads processed purpose
 
 int n_threads, max_mismatch_cell, max_mismatch_feature, umi_len;
 float read_ratio_cutoff;
@@ -270,7 +270,7 @@ void process_reads(ReadParser *parser, int thread_id) {
 		n_reads_valid_umi += n_reads_valid_umi_;
 
 		if (cnt - prev_cnt >= 1000000) {
-			printf("Processed %d reads.\n", cnt.load());
+			printf("Processed %ld reads.\n", cnt.load());
 			prev_cnt = cnt.load();
 		}
 	}
@@ -397,7 +397,7 @@ int main(int argc, char* argv[]) {
 	result_buffer.clear();
 
 	end_ = time(NULL);
-	printf("Parsing input data is finished. %d reads are processed. Time spent = %.2fs.\n", cnt.load(), difftime(end_, interim_));
+	printf("Parsing input data is finished. %ld reads are processed. Time spent = %.2fs.\n", cnt.load(), difftime(end_, interim_));
 	interim_ = end_;
 
 	string output_name = argv[5];


### PR DESCRIPTION
As the sequencing goes deeper, we now see samples of over 2B reads, which causes overflow as this goes over the limit of C++ `int`.

To fix it, I use `long` for read counters.

In addition, add a CI/CD test workflow for PRs.